### PR TITLE
Check that settings are present before use

### DIFF
--- a/wagtailquickcreate/wagtail_hooks.py
+++ b/wagtailquickcreate/wagtail_hooks.py
@@ -13,10 +13,15 @@ class QuickCreatePanel:
     order = 50
 
     def render(self):
+        quick_create_page_types = getattr(settings, "WAGTAIL_QUICK_CREATE_PAGE_TYPES", [])
+
+        if not quick_create_page_types:
+            return ""
+
         # Make a list of the models with edit links
         # EG [{'link': 'news/NewsPage', 'name': 'News page'}]
         page_models = []
-        for i in settings.WAGTAIL_QUICK_CREATE_PAGE_TYPES:
+        for i in quick_create_page_types:
             item = {}
             # When testing, or if the app/model has a specific name
             # target the last 2 list values
@@ -38,11 +43,11 @@ class QuickCreatePanel:
 
         page_models_html_chunk = list(set(page_models_html_chunk))
 
-        if settings.WAGTAIL_QUICK_CREATE_IMAGES:
+        if getattr(settings, "WAGTAIL_QUICK_CREATE_IMAGES", False):
             page_models_html_chunk.append("""
             <a href="/admin/images/multiple/add/"><button class="button bicolor icon icon-plus">Add Image</button></a>
             """)
-        if settings.WAGTAIL_QUICK_CREATE_DOCUMENTS:
+        if getattr(settings, "WAGTAIL_QUICK_CREATE_DOCUMENTS", False):
             page_models_html_chunk.append("""
             <a href="/admin/documents/multiple/add/"><button class="button bicolor icon icon-plus">
             Add Document</button></a>
@@ -64,7 +69,7 @@ def urlconf_time():
 @hooks.register('construct_homepage_panels')
 def add_quick_create_panel(request, panels):
     # Replace the site summary panel with our custom panel
-    if settings.WAGTAIL_QUICK_CREATE_REPLACE_SUMMARY_PANEL:
+    if getattr(settings, "WAGTAIL_QUICK_CREATE_REPLACE_SUMMARY_PANEL", False):
         for i, v in enumerate(panels):
             if isinstance(v, SiteSummaryPanel):
                 panels[i] = QuickCreatePanel()

--- a/wagtailquickcreate/wagtail_hooks.py
+++ b/wagtailquickcreate/wagtail_hooks.py
@@ -33,13 +33,14 @@ class QuickCreatePanel:
             page_models.append(item)
 
         # Build up an html chunk for the links to be rendered in the panel
-        page_models_html_chunk = []
-
-        for i in page_models:
-            page_models_html_chunk.append("""
+        page_models_html_chunk = [
+            """
                 <a href="/admin/quickcreate/create/{model_link}/">
                 <button class="button bicolor icon icon-plus">Add {model_name}</button></a>""".format(
-                model_link=i['link'], model_name=i['name']))
+                model_link=i['link'], model_name=i['name']
+            )
+            for i in page_models
+        ]
 
         page_models_html_chunk = list(set(page_models_html_chunk))
 


### PR DESCRIPTION
Current implementation raises an error if any of the required settings are missing.

I thought it might be a little nicer to provide defaults (and just not render if the page types have not yet been supplied).