### PR TITLE
Fix wagtailcore module path

### DIFF
--- a/wagtailquickcreate/templates/wagtailquickcreate/create.html
+++ b/wagtailquickcreate/templates/wagtailquickcreate/create.html
@@ -29,7 +29,7 @@
 
             {% for page in parent_pages %}
                 <li>
-                    <a href="/admin/pages/add/{{page.app_label|lower}}/{{page.model|lower}}/{{page.id}}/" class="icon icon-plus-inverse icon-larger">
+                    <a href="/admin/pages/add/{{model_app|lower}}/{{page.model|lower}}/{{page.id}}/" class="icon icon-plus-inverse icon-larger">
                         {% for parent in page.ancestors %}
                             {% if not parent.is_root %}
                                 {{ parent }} >

--- a/wagtailquickcreate/views.py
+++ b/wagtailquickcreate/views.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.views.generic import TemplateView
 
-from wagtail.core.models import UserPagePermissionsProxy
+from wagtail.core.models import Page, UserPagePermissionsProxy
 
 
 # Helper function to work out page permissions
@@ -25,7 +25,8 @@ class QuickCreateView(TemplateView):
         _model = kwargs.pop('model')
         app = kwargs.pop('app')
         model = apps.get_model(app, _model)
-        parent_models = model.allowed_parent_page_models()
+        # Exclude base wagtail page class from possible parents
+        parent_models = [m for m in model.allowed_parent_page_models() if m is not Page]
 
         # With the 'allowed parent page' models we have found, get all
         # those objects from the database so we can offer them as parent pages

--- a/wagtailquickcreate/views.py
+++ b/wagtailquickcreate/views.py
@@ -26,7 +26,7 @@ class QuickCreateView(TemplateView):
         app = kwargs.pop('app')
         model = apps.get_model(app, _model)
         # Exclude base wagtail page class from possible parents
-        parent_models = [m for m in model.allowed_parent_page_models() if m is not Page]
+        parent_models = [m for m in model.allowed_parent_page_models() if m is not isinstance(m, Page)]
 
         # With the 'allowed parent page' models we have found, get all
         # those objects from the database so we can offer them as parent pages

--- a/wagtailquickcreate/views.py
+++ b/wagtailquickcreate/views.py
@@ -52,5 +52,6 @@ class QuickCreateView(TemplateView):
             parent_pages.append(item)
 
         context['model_verbose_name'] = model.get_verbose_name()
+        context['model_app'] = app
         context['parent_pages'] = parent_pages
         return context


### PR DESCRIPTION
- Corrects the app name for create link so that it references app of created model not parent
- Exclude base wagtail page class from possible parents 

Because `wagtail.core.models.Page` is an allowed parent, that means list of possible parent pages includes all page types, rather than being limited to those that are allowed.