### PR TITLE
Wagtail 5.1 compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - python: 3.9
-            wagtail: wagtail>=4.1,<5.1
+            wagtail: wagtail>=4.1,<5.2
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/wagtailquickcreate/views.py
+++ b/wagtailquickcreate/views.py
@@ -1,15 +1,14 @@
 from django.apps import apps
 from django.views.generic import TemplateView
 
-from wagtail.models import Page, UserPagePermissionsProxy
+from wagtail.models import Page
 
 
 # Helper function to work out page permissions
 def filter_pages_by_permission(user, pages):
-    user_permissions = UserPagePermissionsProxy(user)
     return [
         page for page in pages
-        if user_permissions.for_page(page).can_add_subpage()
+        if page.permissions_for_user(user).can_add_subpage()
     ]
 
 


### PR DESCRIPTION
[Wagtail 5.1 release notes](https://docs.wagtail.org/en/stable/releases/5.1.html)

Changes:
- [UserPagePermissionsProxy is deprecated](https://docs.wagtail.org/en/stable/releases/5.1.html#userpagepermissionsproxy-is-deprecated)