### PR TITLE
Wagtail 5.1 compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - python: 3.9
-            wagtail: wagtail>=4.1,<5.2
+            wagtail: wagtail>=4.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - python: 3.9
-            wagtail: wagtail>=4.1,<5.1
+            wagtail: wagtail>=4.1,<5.2
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,6 @@ setup(
     install_requires=[
         'wagtail>=4.1',
     ],
-    tests_require=[
-        'wagtail_modeladmin>=1.0',
-    ]
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 4',
         'Framework :: Wagtail :: 5',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     install_requires=[
         'wagtail>=4.1',
     ],
+    tests_require=[
+        'wagtail_modeladmin>=1.0',
+    ]
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/wagtailquickcreate/tests/settings.py
+++ b/wagtailquickcreate/tests/settings.py
@@ -80,3 +80,5 @@ WAGTAIL_QUICK_CREATE_PAGE_TYPES = ['wagtailquickcreate.tests.standardpages.Infor
 USE_TZ = True
 
 WAGTAILADMIN_BASE_URL = 'http://localhost:8000'
+
+STATIC_URL = "/static/"

--- a/wagtailquickcreate/tests/settings.py
+++ b/wagtailquickcreate/tests/settings.py
@@ -1,7 +1,5 @@
 import os
 
-from wagtail import VERSION as WAGTAIL_VERSION
-
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
@@ -21,7 +19,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.routable_page',
     'wagtail.contrib.frontend_cache',
     'wagtail.contrib.settings',
-    'wagtail_modeladmin' if WAGTAIL_VERSION >= (5, 1) else 'wagtail.contrib.modeladmin',
+    'wagtail.contrib.modeladmin',
     'wagtail.contrib.table_block',
     'wagtail.contrib.forms',
     'wagtail.embeds',
@@ -31,7 +29,7 @@ INSTALLED_APPS = [
     'wagtail.documents',
     'wagtail.images',
     'wagtail.admin',
-    'wagtail',
+    "wagtail",
 
     'taggit',
 

--- a/wagtailquickcreate/tests/settings.py
+++ b/wagtailquickcreate/tests/settings.py
@@ -1,5 +1,7 @@
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
@@ -19,7 +21,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.routable_page',
     'wagtail.contrib.frontend_cache',
     'wagtail.contrib.settings',
-    'wagtail.contrib.modeladmin',
+    'wagtail_modeladmin' if WAGTAIL_VERSION >= (5, 1) else 'wagtail.contrib.modeladmin',
     'wagtail.contrib.table_block',
     'wagtail.contrib.forms',
     'wagtail.embeds',
@@ -29,7 +31,7 @@ INSTALLED_APPS = [
     'wagtail.documents',
     'wagtail.images',
     'wagtail.admin',
-    "wagtail",
+    'wagtail',
 
     'taggit',
 

--- a/wagtailquickcreate/views.py
+++ b/wagtailquickcreate/views.py
@@ -1,15 +1,14 @@
 from django.apps import apps
 from django.views.generic import TemplateView
 
-from wagtail.models import Page, UserPagePermissionsProxy
+from wagtail.models import Page
 
 
 # Helper function to work out page permissions
 def filter_pages_by_permission(user, pages):
-    user_permissions = UserPagePermissionsProxy(user)
     return [
         page for page in pages
-        if user_permissions.for_page(page).can_add_subpage()
+        if page.permissions_for_user(user).can_add_subpage()
     ]
 
 


### PR DESCRIPTION
[Wagtail 5.1 release notes](https://docs.wagtail.org/en/stable/releases/5.1.html)

Changes:
- [UserPagePermissionsProxy is deprecated](https://docs.wagtail.org/en/stable/releases/5.1.html#userpagepermissionsproxy-is-deprecated)